### PR TITLE
Remove peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,8 @@
   "author": "Ian VanSchooten",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^1.0"
-  },
-  "peerDependencies": {
-    "eslint": "^0.16.x",
-    "mocha": "^2.0"
+    "chalk": "^1.0",
+    "eslint": "^0.17.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I know peerDependencies seem great, but are unfortunately quite evil (I worked the hard way). Maybe see https://github.com/npm/npm/issues/6565.

Also it is currently throwing:

```
npm WARN peerDependencies The peer dependency eslint@^0.16.x included from mocha-eslint will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```

and it also throws errors on my test project.