### PR TITLE
[ENHANCEMENT] Add acceptance tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "run ESLint as mocha tests",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node tests/runner"
   },
   "keywords": [
     "mocha",
@@ -16,6 +16,10 @@
   "dependencies": {
     "chalk": "^1.0",
     "eslint": "^0.17.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.0",
+    "glob": "4.0.5"
   },
   "repository": {
     "type": "git",

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "parser": "espree",
+  "rules" : {
+    "quotes"  : [2, "single"]
+  },
+  "env": {
+    "node": true
+  }
+}

--- a/tests/acceptance/acceptanceTest.js
+++ b/tests/acceptance/acceptanceTest.js
@@ -1,0 +1,37 @@
+/*eslint-env node, mocha */
+'use strict';
+
+// var Mocha = require('mocha');
+
+var runTest = require('../helpers/testRunner.js').runTest;
+
+describe('Acceptance: mocha-eslint', function() {
+
+  it('should pass test for lintSucceed.js', function (done) {
+    runTest('tests/lint/passingLintTest.js', function (results) {
+      if (results[3].indexOf('1 passing') === -1) {
+        throw new Error('Did not get a passing test');
+      };
+      done()
+    });
+  })
+
+  it('should fail test for lintFail.js', function (done) {
+    runTest('tests/lint/failingLintTest.js', function (results) {
+      if (results[4].indexOf('1 failing') === -1) {
+        throw new Error('Did not get a failing test');
+      };
+      done()
+    });
+  })
+
+  it('should test multiple paths correctly', function (done) {
+    runTest('tests/lint/multiplePathTest.js', function (results) {
+      if (results[3].indexOf('1 passing') === -1 ||
+        results[4].indexOf('1 failing') === -1) {
+        throw new Error('Did not get a single pass and single failure');
+      };
+      done()
+    });
+  });
+});

--- a/tests/fixtures/failing/lintFail.js
+++ b/tests/fixtures/failing/lintFail.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log("this should fail quote rule");

--- a/tests/fixtures/passing/lintSucceed.js
+++ b/tests/fixtures/passing/lintSucceed.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('this should pass quote rule');

--- a/tests/helpers/testRunner.js
+++ b/tests/helpers/testRunner.js
@@ -1,0 +1,30 @@
+/*eslint no-process-exit:0*/
+'use strict';
+
+var glob  = require('glob');
+var Mocha = require('mocha');
+
+function runTest(file, callback) {
+
+  var mocha = new Mocha({
+    // For some reason, tests take a long time on Windows (or at least AppVeyor)
+    timeout: (process.platform === 'win32') ? 10000 : 2000,
+    reporter: 'min'
+  });
+
+  mocha.addFile(file);
+
+  var output, originalWrite;
+  output = [];
+  originalWrite = process.stdout.write;
+  process.stdout.write = function(str) {
+    output.push(str.toString('utf8'));
+  };
+
+  mocha.run(function (failures) {
+    process.stdout.write = originalWrite;
+    callback(output);
+  });
+}
+
+exports.runTest = runTest;

--- a/tests/lint/failingLintTest.js
+++ b/tests/lint/failingLintTest.js
@@ -1,0 +1,8 @@
+/*eslint-env node, mocha */
+'use strict';
+
+var lint = require('../../index.js');
+var paths = ['tests/fixtures/failing'];
+var options = { formatter: 'stylish' };
+
+lint(paths, options);

--- a/tests/lint/multiplePathTest.js
+++ b/tests/lint/multiplePathTest.js
@@ -1,0 +1,8 @@
+/*eslint-env node, mocha */
+'use strict';
+
+var lint = require('../../index.js');
+var paths = ['tests/fixtures/passing', 'tests/fixtures/failing'];
+var options = { formatter: 'stylish' };
+
+lint(paths, options);

--- a/tests/lint/passingLintTest.js
+++ b/tests/lint/passingLintTest.js
@@ -1,0 +1,8 @@
+/*eslint-env node, mocha */
+'use strict';
+
+var lint = require('../../index.js');
+var paths = ['tests/fixtures/passing'];
+var options = { formatter: 'stylish' };
+
+lint(paths, options);

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,0 +1,33 @@
+/*eslint no-process-exit:0*/
+'use strict';
+
+var glob  = require('glob');
+var Mocha = require('mocha');
+var chalk = require('chalk');
+
+var mocha = new Mocha({
+  // For some reason, tests take a long time on Windows (or at least AppVeyor)
+  timeout: (process.platform === 'win32') ? 90000 : 18000,
+  reporter: 'spec'
+});
+
+var root = 'tests/acceptance';
+
+function addFiles(mocha, files) {
+  glob.sync(root + files).forEach(mocha.addFile.bind(mocha));
+}
+
+addFiles(mocha, '/**/*Test.js');
+
+mocha.run(function (failures) {
+  process.on('exit', function () {
+    if (failures === 1) {
+      console.log(chalk.red('1 Failing Test'));
+    } else if (failures > 1) {
+      console.log(chalk.red(failures, 'Failing Tests'));
+    } else if (failures === 0) {
+      console.log(chalk.green('All Tests Passed!'));
+    }
+    process.exit(failures);
+  });
+});


### PR DESCRIPTION
Because the purpose of the mocha-eslint module is to run mocha tests which
check for ESLint errors, the acceptance tests must themselves also run such tests.

Therefore, the testing strategy is to execute a test file similar to what a consuming
module might use.  Basically, this means running a mocha test (mocha-eslint) inside
of mocha tests (the acceptance tests).

To do this, the stdout of the mocha-eslint tests need to be captured and then
checked for expected results.  The way this is accomplished is using the snippet
provided by @danielstjules in https://github.com/mochajs/mocha/issues/138#issuecomment-82727410

So far, the following tests are being performed:

- Verify that a test of a file which should not give ESLint warnings passes
- Verify that a test of a file which should give ESLint warnings does in fact fail
- Verify that a test of multiple paths works correctly.