### PR TITLE
Fix #7: Display warnings when tests pass

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,13 @@ module.exports = function (paths, options) {
             chalk.red('Code did not pass lint rules') +
             formatter(report.results)
           );
+        } else if (
+          report &&
+          report.warningCount > 0
+        ) {
+          console.log(formatter(report.results));
         }
+
       });
     });
   });

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,6 +1,7 @@
 {
   "parser": "espree",
   "rules" : {
+    "camelcase": 1,
     "quotes"  : [2, "single"]
   },
   "env": {

--- a/tests/acceptance/acceptanceTest.js
+++ b/tests/acceptance/acceptanceTest.js
@@ -34,4 +34,16 @@ describe('Acceptance: mocha-eslint', function() {
       done()
     });
   });
+
+  it('should display warnings if no errors are present, but still pass', function (done) {
+    runTest('tests/lint/warningLintTest.js', function (results) {
+      if (results[2].indexOf('warning') === -1) {
+        throw new Error('Did not give a warning');
+      }
+      if (results[4].indexOf('1 passing') === -1) {
+        throw new Error('Did not pass test');
+      }
+      done();
+    });
+  });
 });

--- a/tests/fixtures/warning/lintWarn.js
+++ b/tests/fixtures/warning/lintWarn.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var var_with_underscores = 'string';
+
+console.log(var_with_underscores);

--- a/tests/lint/warningLintTest.js
+++ b/tests/lint/warningLintTest.js
@@ -1,0 +1,8 @@
+/*eslint-env node, mocha */
+'use strict';
+
+var lint = require('../../index.js');
+var paths = ['tests/fixtures/warning'];
+var options = { formatter: 'stylish' };
+
+lint(paths, options);


### PR DESCRIPTION
If an ESLint rule is configured to throw a warning, it should not
cause the test to fail, but should display the warning.