### PR TITLE
Close #6: Support globbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # mocha-eslint Changelog
 
 ### MASTER
+* [ENHANCEMENT] Add ability to pass glob patterns as arguments
 * [BUGFIX] Display ESLint warnings even if tests pass
 
 ### v.0.1.1

--- a/index.js
+++ b/index.js
@@ -1,37 +1,49 @@
 var CLIEngine = require('eslint').CLIEngine;
 var chalk = require('chalk');
+var glob = require('glob');
 var cli = new CLIEngine({});
-var format = '';
+var format;
 
-module.exports = function (paths, options) {
+
+function test(p) {
+  it('should have no errors in ' + p, function () {
+    try {
+      var report = cli.executeOnFiles([p]);
+      var formatter = cli.getFormatter(format);
+    } catch (err) {
+      throw new Error(err);
+    }
+    if (
+      report &&
+      report.errorCount > 0
+    ) {
+      throw new Error(
+        chalk.red('Code did not pass lint rules') +
+        formatter(report.results)
+      );
+    } else if (
+      report &&
+      report.warningCount > 0
+    ) {
+      console.log(formatter(report.results));
+    }
+
+  });
+}
+
+module.exports = function (patterns, options) {
   if (options && options.formatter) {
     format = options.formatter;
   }
   describe('eslint', function () {
-    paths.forEach(function (p) {
-      it('should have no errors in ' + p, function () {
-        try {
-          var report = cli.executeOnFiles([p]);
-          var formatter = cli.getFormatter(format);
-        } catch (err) {
-          throw new Error(err);
-        }
-        if (
-          report &&
-          report.errorCount > 0
-        ) {
-          throw new Error(
-            chalk.red('Code did not pass lint rules') +
-            formatter(report.results)
-          );
-        } else if (
-          report &&
-          report.warningCount > 0
-        ) {
-          console.log(formatter(report.results));
-        }
-
-      });
+    patterns.forEach(function (pattern) {
+      if (glob.hasMagic(pattern)) {
+        glob.sync(pattern).forEach(function (file) {
+          test(file);
+        });
+      } else {
+        test(pattern);
+      }
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "mocha": "^2.0",
-    "glob": "4.0.5"
+    "glob": "5.0.3"
   },
   "repository": {
     "type": "git",

--- a/tests/acceptance/acceptanceTest.js
+++ b/tests/acceptance/acceptanceTest.js
@@ -46,4 +46,14 @@ describe('Acceptance: mocha-eslint', function() {
       done();
     });
   });
+
+  it('should accept glob patterns', function (done) {
+    runTest('tests/lint/globLintTest.js', function (results) {
+      if (results[3].indexOf('1 passing') === -1 ||
+        results[4].indexOf('1 failing') === -1) {
+        throw new Error('Did not get a single pass and single failure');
+      }
+      done();
+    });
+  });
 });

--- a/tests/helpers/testRunner.js
+++ b/tests/helpers/testRunner.js
@@ -1,7 +1,6 @@
 /*eslint no-process-exit:0*/
 'use strict';
 
-var glob  = require('glob');
 var Mocha = require('mocha');
 
 function runTest(file, callback) {

--- a/tests/lint/globLintTest.js
+++ b/tests/lint/globLintTest.js
@@ -1,0 +1,8 @@
+/*eslint-env node, mocha */
+'use strict';
+
+var lint = require('../../index.js');
+var paths = ['tests/fixtures/{passing,failing}'];
+var options = { formatter: 'stylish' };
+
+lint(paths, options);


### PR DESCRIPTION
It is now possible to pass in a glob pattern in the same way that
a path would be passed.  In fact, they should be together in the same array.

Currently, a seperate test case will be generated and run against each file that
the glob pattern returns.