### PR TITLE
.npmignore: fix tests folder, rm node_modules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
-node_modules
-test
+tests
 .gitignore
 test.js
 *.sublime*


### PR DESCRIPTION
node_modules are ignored by default, see https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package