### PR TITLE
Update to ESLint 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # mocha-eslint Changelog
 
 ### MASTER
+- [BREAKING] Update to ESLint 1.0.0
 
 ### v0.2.0
 * [ENHANCEMENT] Add alwaysWarn option, defaults to true

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.0",
-    "eslint": "^0.24.0",
-    "glob": "5.0.5"
+    "eslint": "^1.0.0",
+    "glob": "^5.0.14"
   },
   "devDependencies": {
     "mocha": "^2.0"


### PR DESCRIPTION
Fixes #23

This is a breaking change, as ESLint 1.0.0 has breaking changes.
See http://eslint.org/docs/user-guide/migrating-to-1.0.0 for details how to migrate.