### PR TITLE
Make 'eslint' peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "eslint": "^1.0.0"
-  }
+  },
   "devDependencies": {
     "mocha": "^2.0"
   },

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.0",
-    "eslint": "^1.0.0",
     "glob": "^5.0.14"
   },
+  "peerDependencies": {
+    "eslint": "^1.0.0"
+  }
   "devDependencies": {
     "mocha": "^2.0"
   },


### PR DESCRIPTION
By making 'eslint' a peer dependency, it can be upgraded independently from 'mocha-eslint'