### PR TITLE
Allow timeout for test to be specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ options.formatter = 'compact';
 // Only display warnings if a test is failing
 options.alwaysWarn = false; // Defaults to true, always show warnings
 
+// Increase the timeout of the test if linting takes to long
+options.timeout = 5000; // Defaults to the global mocha timeout option
+
 // Run the tests
 lint(paths, options);
 ```

--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ var cli = new CLIEngine({});
 function test(p, opts) {
   it('should have no errors in ' + p, function () {
     var format, warn;
+
+    if (opts && opts.timeout) {
+      this.timeout(opts.timeout);
+    }
+
     if (opts && opts.formatter) {
       format = opts.formatter;
     }


### PR DESCRIPTION
My eslint run can take 2171ms when I use `babel-eslint`. The default mocha timeout is 2000ms. So `mocha-eslint` always fails.

This adds an option allowing the timeout to be changed.