### PR TITLE
Support for ESLint@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.1.0",
-    "eslint": "^1.0.0",
+    "eslint": "^2.0.0",
     "glob-all": "^3.0.1"
   },
   "devDependencies": {

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,5 +1,4 @@
 {
-  "parser": "espree",
   "rules" : {
     "camelcase": 1,
     "quotes"  : [2, "single"]


### PR DESCRIPTION
This PR adds support for ESLint 2.0.0 and above. Installing this package will now automatically install the latest 2.x version of ESLint, but using a lower version is still supported.

The TravisCI build config is also adjusted to test both versions now.

resolves #30 