### PR TITLE
Use Promises to run acceptance tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "glob-all": "^3.0.1"
   },
   "devDependencies": {
+    "es6-promise": "^3.1.2",
     "mocha": "^2.2.5"
   },
   "repository": {

--- a/tests/acceptance/acceptanceTest.js
+++ b/tests/acceptance/acceptanceTest.js
@@ -1,23 +1,20 @@
 /*eslint-env node, mocha */
 'use strict';
 
-// var Mocha = require('mocha');
-
 var runTest = require('../helpers/testRunner.js').runTest;
 
 describe('Acceptance: mocha-eslint', function () {
 
-  it('should pass test for lintSucceed.js', function (done) {
-    runTest('tests/lint/passingLintTest.js', function (results) {
+  it('should pass test for lintSucceed.js', function () {
+    return runTest('tests/lint/passingLintTest.js').then(function (results) {
       if (results[3].indexOf('1 passing') === -1) {
         throw new Error('Did not get a passing test');
       }
-      done();
     });
   });
 
-  it('should fail test for lintFail.js', function (done) {
-    runTest('tests/lint/failingLintTest.js', function (results) {
+  it('should fail test for lintFail.js', function () {
+    return runTest('tests/lint/failingLintTest.js').then(function (results) {
       if (results[4].indexOf('1 failing') === -1) {
         throw new Error('Did not get a failing test');
       }
@@ -29,84 +26,75 @@ describe('Acceptance: mocha-eslint', function () {
       if (reasonsCount !== 1) {
         throw new Error('Counted ' + reasonsCount + " failure reasons");
       }
-
-      done();
     });
   });
 
-  it('should test multiple paths correctly', function (done) {
-    runTest('tests/lint/multiplePathTest.js', function (results) {
+  it('should test multiple paths correctly', function () {
+    return runTest('tests/lint/multiplePathTest.js').then(function (results) {
       if (results[3].indexOf('1 passing') === -1 ||
         results[4].indexOf('1 failing') === -1) {
         throw new Error('Did not get a single pass and single failure');
       }
-      done();
     });
   });
 
-  it('should display warnings if no errors are present, but still pass', function (done) {
-    runTest('tests/lint/warningTrueLintTest.js', function (results) {
+  it('should display warnings if no errors are present, but still pass', function () {
+    return runTest('tests/lint/warningTrueLintTest.js').then(function (results) {
       if (results[2].indexOf('warning') === -1) {
         throw new Error('Did not give a warning');
       }
       if (results[4].indexOf('1 passing') === -1) {
         throw new Error('Did not pass test');
       }
-      done();
     });
   });
 
-  it('should not display warnings if alwaysWarn is false', function (done) {
-    runTest('tests/lint/warningFalseLintTest.js', function (results) {
+  it('should not display warnings if alwaysWarn is false', function () {
+    return runTest('tests/lint/warningFalseLintTest.js').then(function (results) {
       if (results[2].indexOf('warning') !== -1) {
         throw new Error('Gave a warning');
       }
       if (results[3].indexOf('1 passing') === -1) {
         throw new Error('Did not pass test');
       }
-      done();
     });
   });
 
-  it('should display warnings if alwaysWarn is not specified', function (done) {
-    runTest('tests/lint/warningDefaultLintTest.js', function (results) {
+  it('should display warnings if alwaysWarn is not specified', function () {
+    return runTest('tests/lint/warningDefaultLintTest.js').then(function (results) {
       if (results[2].indexOf('warning') === -1) {
         throw new Error('Did not give a warning');
       }
       if (results[4].indexOf('1 passing') === -1) {
         throw new Error('Did not pass test');
       }
-      done();
     });
   });
 
-  it('should accept glob patterns', function (done) {
-    runTest('tests/lint/globLintTest.js', function (results) {
+  it('should accept glob patterns', function () {
+    return runTest('tests/lint/globLintTest.js').then(function (results) {
       if (results[3].indexOf('1 passing') === -1 ||
         results[4].indexOf('1 failing') === -1) {
         throw new Error('Did not get a single pass and single failure');
       }
-      done();
     });
   });
 
-  it('should accept multiple glob patterns', function (done) {
-    runTest('tests/lint/multiGlobLintTest.js', function (results) {
+  it('should accept multiple glob patterns', function () {
+    return runTest('tests/lint/multiGlobLintTest.js').then(function (results) {
       if (results[3].indexOf('1 passing') === -1 ||
         results[4].indexOf('1 failing') === -1) {
         throw new Error('Did not get a single pass and single failure');
       }
-      done();
     });
   });
 
-  it('should accept glob patterns using negation', function (done) {
-    runTest('tests/lint/negatedGlobLintTest.js', function (results) {
+  it('should accept glob patterns using negation', function () {
+    return runTest('tests/lint/negatedGlobLintTest.js').then(function (results) {
       if (results[3].indexOf('1 passing') === -1 ||
         results[4].indexOf('1 failing') !== -1) {
         throw new Error('Did not get a single pass');
       }
-      done();
     });
   });
 });

--- a/tests/helpers/testRunner.js
+++ b/tests/helpers/testRunner.js
@@ -2,8 +2,9 @@
 'use strict';
 
 var Mocha = require('mocha');
+var Promise = require('es6-promise').Promise;
 
-function runTest(file, callback) {
+function runTest(file) {
 
   var mocha = new Mocha({
     // For some reason, tests take a long time on Windows (or at least AppVeyor)
@@ -20,10 +21,12 @@ function runTest(file, callback) {
     output.push(str.toString('utf8'));
   };
 
-  mocha.run(function (failures) {
-    process.stdout.write = originalWrite;
-    callback(output);
-  });
+  return new Promise(function(resolve) {
+    mocha.run(function (failures) {
+      process.stdout.write = originalWrite;
+      resolve(output);
+    });
+  })
 }
 
 exports.runTest = runTest;


### PR DESCRIPTION
Using Promises reduces the risk of forgetting to call the `done()` callback and seems to be better at catching errors in some situations.