### PR TITLE
Use "replaceall" for relative -> absolute path replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var CLIEngine = require('eslint').CLIEngine;
 var chalk = require('chalk');
 var globAll = require('glob-all');
+var replaceAll = require("replaceall");
 var cli = new CLIEngine({});
 
 
@@ -32,7 +33,7 @@ function test(p, opts) {
       throw new Error(
         chalk.red('Code did not pass lint rules') +
         // remove process.cwd() to convert absolute to relative paths
-        formatter(report.results).replace(process.cwd() + '/', '')
+        replaceAll(process.cwd() + '/', '', formatter(report.results))
       );
     } else if (
       warn &&

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "chalk": "^1.1.0",
     "eslint": "^2.0.0",
-    "glob-all": "^3.0.1"
+    "glob-all": "^3.0.1",
+    "replaceall": "^0.1.6"
   },
   "devDependencies": {
     "es6-promise": "^3.1.2",

--- a/tests/acceptance/acceptanceTest.js
+++ b/tests/acceptance/acceptanceTest.js
@@ -29,6 +29,22 @@ describe('Acceptance: mocha-eslint', function () {
     });
   });
 
+  it('should fail test for multiple-failing fixture', function () {
+    return runTest('tests/lint/multipleFailingLintTest.js').then(function (results) {
+      if (results[4].indexOf('1 failing') === -1) {
+        throw new Error('Did not get a failing test');
+      }
+
+      var reasonsCount = results[6].split('\n')
+          .filter(function(line) { return line.indexOf('Code did not pass lint rules') !== -1; })
+          .length;
+
+      if (reasonsCount !== 1) {
+        throw new Error('Counted ' + reasonsCount + " failure reasons");
+      }
+    });
+  });
+
   it('should test multiple paths correctly', function () {
     return runTest('tests/lint/multiplePathTest.js').then(function (results) {
       if (results[3].indexOf('1 passing') === -1 ||

--- a/tests/fixtures/multiple-failing/lintFail.js
+++ b/tests/fixtures/multiple-failing/lintFail.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log("this should fail quote rule");

--- a/tests/fixtures/multiple-failing/lintFailTwo.js
+++ b/tests/fixtures/multiple-failing/lintFailTwo.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log("this should fail quote rule");

--- a/tests/lint/multipleFailingLintTest.js
+++ b/tests/lint/multipleFailingLintTest.js
@@ -1,0 +1,8 @@
+/*eslint-env node, mocha */
+'use strict';
+
+var lint = require('../../index.js');
+var paths = ['tests/fixtures/multiple-failing'];
+var options = { formatter: 'stylish' };
+
+lint(paths, options);


### PR DESCRIPTION
This PR resolves #29 again...

The issue was fixed in #33 but only for cases where there is only a single file with a lint error because the `replace()` method in JS only replaces the first instance by default... :facepalm: