### PR TITLE
Adds support for 'slow' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ var options = {
   // Increase the timeout of the test if linting takes to long
   timeout: 5000,  // Defaults to the global mocha `timeout` option
 
+  // Increase the time until a test is marked as slow
+  slow: 1000,  // Defaults to the global mocha `slow` option
+
   // Consider linting warnings as errors and return failure
   strict: true  // Defaults to `false`, only notify the warnings
 };

--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ function test(p, opts) {
       this.timeout(opts.timeout);
     }
 
+    if (opts && opts.slow) {
+      this.slow(opts.slow);
+    }
+
     if (opts && opts.formatter) {
       format = opts.formatter;
     }


### PR DESCRIPTION
Seeing as 'timeout' is already an option, it's trivial to add support for 'slow' so that (slightly)longer running lint tasks do not get marked as slow. Thoughts?