### PR TITLE
fallback for run with undefined options

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,22 +6,23 @@ var cli = new CLIEngine({});
 
 
 function test(p, opts) {
+  opts = opts || {};
   it('should have no errors in ' + p, function () {
     var format, warn;
 
-    if (opts && opts.timeout) {
+    if (opts.timeout) {
       this.timeout(opts.timeout);
     }
 
-    if (opts && opts.slow) {
+    if (opts.slow) {
       this.slow(opts.slow);
     }
 
-    if (opts && opts.formatter) {
+    if (opts.formatter) {
       format = opts.formatter;
     }
 
-    if (opts && opts.hasOwnProperty('alwaysWarn')) {
+    if (opts.hasOwnProperty('alwaysWarn')) {
       warn = opts.alwaysWarn;
     } else {  // Show warnings by default
       warn = true;


### PR DESCRIPTION
In some projects, I can simply use mocha-eslint without options.
This PR fixed bug, that was introduced in https://github.com/BadgeLabs/mocha-eslint/commit/8dccc53f211e20b4c479cdb6bb4c5aeb6f043944#diff-168726dbe96b3ce427e7fedce31bb0bcR30, where `opts &&` is missing
+ instead of checking for `opts` each time it's better to have on fallback on a top of a function

This bug was found in this travis build: https://travis-ci.org/debitoor/chai-subset/jobs/136600628, when greenkeeper.io tried to update mocha-eslint to the latest