### PR TITLE
Publish even less files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-tests
-.gitignore
-test.js
-*.sublime*

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "bugs": {
     "url": "https://github.com/BadgeLabs/mocha-eslint/issues"
   },
-  "homepage": "https://github.com/BadgeLabs/mocha-eslint"
+  "homepage": "https://github.com/BadgeLabs/mocha-eslint",
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
To minimize the number of published files with npm, it's good to use 'files' property in package.json. So instead of "ignore some files" we can say "publish only some files", so even fewer files will be published.
Check this out: https://docs.npmjs.com/files/package.json#files