### PR TITLE
Added overridable context name for mocha reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ var options = {
   slow: 1000,  // Defaults to the global mocha `slow` option
 
   // Consider linting warnings as errors and return failure
-  strict: true  // Defaults to `false`, only notify the warnings
+  strict: true,  // Defaults to `false`, only notify the warnings
+
+  // Specify the mocha context in which to run tests
+  contextName: 'eslint',  // Defaults to `eslint`, but can be any string
 };
 
 // Run the tests

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var globAll = require('glob-all');
 var replaceAll = require("replaceall");
 var cli = new CLIEngine({});
 
-
 function test(p, opts) {
   opts = opts || {};
   it('should have no errors in ' + p, function () {
@@ -51,7 +50,8 @@ function test(p, opts) {
 }
 
 module.exports = function (patterns, options) {
-  describe('eslint', function () {
+  var contextName = (options && options.contextName) || 'eslint';
+  describe(contextName, function () {
     globAll.sync(patterns).forEach(function (file) {
       test(file, options);
     });

--- a/tests/acceptance/acceptanceTest.js
+++ b/tests/acceptance/acceptanceTest.js
@@ -24,7 +24,7 @@ describe('Acceptance: mocha-eslint', function () {
           .length;
 
       if (reasonsCount !== 1) {
-        throw new Error('Counted ' + reasonsCount + " failure reasons");
+        throw new Error('Counted ' + reasonsCount + ' failure reasons');
       }
     });
   });
@@ -40,7 +40,7 @@ describe('Acceptance: mocha-eslint', function () {
           .length;
 
       if (reasonsCount !== 1) {
-        throw new Error('Counted ' + reasonsCount + " failure reasons");
+        throw new Error('Counted ' + reasonsCount + ' failure reasons');
       }
     });
   });
@@ -110,6 +110,30 @@ describe('Acceptance: mocha-eslint', function () {
       if (results[3].indexOf('1 passing') === -1 ||
         results[4].indexOf('1 failing') !== -1) {
         throw new Error('Did not get a single pass');
+      }
+    });
+  });
+
+  it('should mocha context should default to `eslint` when not defined', function () {
+      return runTest('tests/lint/contextNoOverrideTest.js', { reporter: 'spec' }).then(function (results) {
+        if (results[2].indexOf('eslint') === -1) {
+          throw new Error('Did not default the context name');
+        }
+      });
+  });
+
+  it('should overwrite mocha context name when options is passed in', function () {
+    return runTest('tests/lint/contextOverrideTest.js', { reporter: 'spec' }).then(function (results) {
+      if (results[2].indexOf('overridden context') === -1) {
+        throw new Error('Did not override the context name');
+      }
+    });
+  });
+
+  it('should run successfully without passign options', function () {
+    return runTest('tests/lint/contextNoOptionsTest.js').then(function (results) {
+      if (results[3].indexOf('1 passing') === -1) {
+        throw new Error('Did not get a passing test');
       }
     });
   });

--- a/tests/helpers/testRunner.js
+++ b/tests/helpers/testRunner.js
@@ -4,12 +4,12 @@
 var Mocha = require('mocha');
 var Promise = require('es6-promise').Promise;
 
-function runTest(file) {
-
+function runTest(file, options) {
+  options = options || {};
   var mocha = new Mocha({
     // For some reason, tests take a long time on Windows (or at least AppVeyor)
     timeout: (process.platform === 'win32') ? 10000 : 2000,
-    reporter: 'min'
+    reporter: options.reporter || 'min',
   });
 
   mocha.addFile(file);

--- a/tests/lint/contextNoOptionsTest.js
+++ b/tests/lint/contextNoOptionsTest.js
@@ -1,0 +1,7 @@
+/*eslint-env node, mocha */
+'use strict';
+
+var lint = require('../../index.js');
+var paths = ['tests/fixtures/passing'];
+
+lint(paths);

--- a/tests/lint/contextNoOverrideTest.js
+++ b/tests/lint/contextNoOverrideTest.js
@@ -1,0 +1,8 @@
+/*eslint-env node, mocha */
+'use strict';
+
+var lint = require('../../index.js');
+var paths = ['tests/fixtures/passing'];
+var options = {};
+
+lint(paths, options);

--- a/tests/lint/contextOverrideTest.js
+++ b/tests/lint/contextOverrideTest.js
@@ -1,0 +1,8 @@
+/*eslint-env node, mocha */
+'use strict';
+
+var lint = require('../../index.js');
+var paths = ['tests/fixtures/passing'];
+var options = { contextName: 'overridden context' };
+
+lint(paths, options);


### PR DESCRIPTION
- exporting the `test` function for for use in custom mocha contexts
Resolves #54