### PR TITLE
eslint as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,17 @@
   ],
   "author": "Ian VanSchooten",
   "license": "MIT",
+  "peerDependencies": {
+    "eslint": ">=3"
+  },
   "dependencies": {
     "chalk": "^2.4.2",
-    "eslint": "^6.6.0",
     "glob-all": "^3.1.0",
     "replaceall": "^0.1.6"
   },
   "devDependencies": {
     "es6-promise": "^4.2.8",
+    "eslint": "^6.6.0",
     "mocha": "^6.2.2"
   },
   "repository": {


### PR DESCRIPTION
Since the hosting package likely has eslint already installed at a given version, it makes sense to make this a peer dependency so that whatever version they are using is the same version used in the testing instead of always using version ^6.6.0.  I ran the tests back to v3.0.0 of eslint and they all passed, I'm not sure if it would catch problems with eslint versions, please feel free to modify the earliest version this utility works with.